### PR TITLE
Use cwindow to not show an empty quickfix

### DIFF
--- a/autoload/testdrive.vim
+++ b/autoload/testdrive.vim
@@ -80,7 +80,7 @@ function testdrive#test()
       " TODO: Why does shellescape break this?
       cexpr system(prg)
       if g:testdrive#always_open_results
-        copen
+        cwindow
       endif
     endif
     let &errorformat=oldErrorFormat


### PR DESCRIPTION
The empty quickfix window after all tests pass was annoying. I just swapped `copen` to `cwindow` and it only pops up after failures now.
